### PR TITLE
now that Simple AF has a systemctl facade that can restart grumpyscre…

### DIFF
--- a/guppyscreen.json
+++ b/guppyscreen.json
@@ -38,7 +38,7 @@
             "id": "output_pin fan1"
         }
     ],
-    "guppy_restart_cmd": "/etc/init.d/S99guppyscreen restart",
+    "guppy_restart_cmd": "sudo systemctl restart grumpyscreen",
     "invert_z_icon": false,
     "leds": [
         {

--- a/release.sh
+++ b/release.sh
@@ -20,7 +20,6 @@ if [ "$ASSET_NAME" = "guppyscreen-smallscreen" ]; then
   sed -i 's/"display_rotate": 3/"display_rotate": 2/g' $RELEASES_DIR/guppyscreen.json
 elif [ "$ASSET_NAME" = "guppyscreen-rpi" ]; then
   sed -i 's/"display_rotate": 3/"display_rotate": 0/g' $RELEASES_DIR/guppyscreen.json
-  sed -i 's:/etc/init.d/S99guppyscreen restart:sudo systemctl restart grumpyscreen:g' $RELEASES_DIR/guppyscreen.json
   sed -i 's:/etc/init.d/S58factoryreset::g' $RELEASES_DIR/guppyscreen.json
 fi
 tar czf $ASSET_NAME.tar.gz -C releases .


### PR DESCRIPTION
…en we do not need the hack in release.sh